### PR TITLE
fix: allow mapped Deepseek model ID in ByteDance API authorization

### DIFF
--- a/app/api/bytedance.ts
+++ b/app/api/bytedance.ts
@@ -87,13 +87,30 @@ async function request(req: NextRequest) {
       const jsonBody = JSON.parse(clonedBody) as { model?: string };
 
       // not undefined and is false
+      let isAvailable = !isModelNotavailableInServer(
+        serverConfig.customModels,
+        jsonBody?.model as string,
+        ServiceProvider.ByteDance as string,
+      );
+
       if (
-        isModelNotavailableInServer(
+        !isAvailable &&
+        jsonBody?.model === "deepseek-v3-2-251201" &&
+        (!isModelNotavailableInServer(
           serverConfig.customModels,
-          jsonBody?.model as string,
+          "deepseek-v3-2",
           ServiceProvider.ByteDance as string,
-        )
+        ) ||
+          !isModelNotavailableInServer(
+            serverConfig.customModels,
+            "deepseek-v3-2-thinking",
+            ServiceProvider.ByteDance as string,
+          ))
       ) {
+        isAvailable = true;
+      }
+
+      if (!isAvailable) {
         return NextResponse.json(
           {
             error: true,


### PR DESCRIPTION
- Updated `app/api/bytedance.ts` to permit requests for `deepseek-v3-2-251201` if either `deepseek-v3-2` or `deepseek-v3-2-thinking` is authorized in `CUSTOM_MODELS`.
- This ensures that the client-side model mapping works correctly with server-side whitelist validation.